### PR TITLE
Remove id from getMany instances API.

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -54,17 +54,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       res.json(record);
     }));
 
-  // get one or more issuer instances
+  // get issuer instances
   app.get(
     routes.instances,
     ensureAuthenticated,
     asyncHandler(async (req, res) => {
-      const {id, controller} = req.query;
-      if(id) {
-        const record = await vcIssuer.instances.get({id});
-        res.json(record);
-        return;
-      }
+      const {controller} = req.query;
       const records = await vcIssuer.instances.getAll({controller});
       res.json(records);
     }));


### PR DESCRIPTION
Fixes #8.

The get one API was already in place.