### PR TITLE
Fix instance creation

### DIFF
--- a/lib/http.js
+++ b/lib/http.js
@@ -152,14 +152,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       // VP must be presented by the issuer
       const {holder: issuer, capability} = vp;
-
       // create instance, including zcaps
       await vcIssuer.instances.setIssuer({
         id, controller, issuer, zcaps: capability
       });
-
       // upsert admin users for every controller of the instance
-      await vcIssuer.users.upsertAdmins({id});
+      await vcIssuer.users.upsertAdmins({instanceId: id});
 
       res.status(204).end();
     }));

--- a/lib/instances.js
+++ b/lib/instances.js
@@ -104,7 +104,7 @@ exports.create = async ({instance}) => {
 // get a particular instance
 exports.get = async ({id, controller}) => {
   assert.string(id, 'id');
-  assert.optionalString('controller', controller);
+  assert.optionalString(controller, 'controller');
 
   const query = {'instance.id': id};
   // TODO: determine `public` status of information in instance
@@ -177,8 +177,8 @@ exports.getControllerKey = async ({id}) => {
 // set issuer and capabilities (zcaps) for an instance
 exports.setIssuer = async ({id, controller, issuer, zcaps}) => {
   assert.string(id, 'id');
-  assert.object('issuer', issuer);
-  assert.array('zcaps', zcaps);
+  assert.string(issuer, 'issuer');
+  assert.array(zcaps, 'zcaps');
   assert.optionalString(controller, 'controller');
 
   const query = {'instance.id': id};

--- a/lib/instances.js
+++ b/lib/instances.js
@@ -137,7 +137,7 @@ exports.getAll = async ({controller} = {}) => {
 // remove an issuer instance
 exports.remove = async ({id, controller}) => {
   assert.string(id, 'id');
-  assert.optionalString('controller', controller);
+  assert.optionalString(controller, 'controller');
 
   const query = {'instance.id': id};
   if(controller) {
@@ -207,8 +207,8 @@ exports.setIssuer = async ({id, controller, issuer, zcaps}) => {
 // get a capability for an instance by reference ID
 exports.getCapability = async ({instance, id, referenceId}) => {
   assert.object(instance, 'instance');
-  assert.optionalString('id', id);
-  assert.optionalString('referenceId', referenceId);
+  assert.optionalString(id, 'id');
+  assert.optionalString(referenceId, 'referenceId');
 
   if(referenceId) {
     return instance.zcaps.find(c => c.referenceId === referenceId);


### PR DESCRIPTION
This fixes the final bug in instance creation.
I summarized the problems here:

https://github.com/digitalbazaar/bedrock-vc-issuer/issues/24

Basically assert.object was being called on the string 'issuer' then the actual
issuer parameter being passed in is also a string then database.hash expects a string
and not an object and finally upsertAdmins' parameters were changed so
that `instanceId` is passed in instead of id which is does not see.

I can now reliably create a new instance, however that new instance also has bugs I will need to look into.