### PR TITLE
Add issuer instance api

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vc-issuer ChangeLog
 
+## 0.1.1 -
+
+### Added
+- An API endpoint that takes the issuer instance in it's route.
+
 ## 0.1.0 - 2019-xx-xx
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,7 @@
 # bedrock-vc-issuer ChangeLog
 
-## 0.1.1 -
-
-### Added
-- An API endpoint that takes the issuer instance in it's route.
-
-## 0.1.0 - 2019-xx-xx
+## 1.0.0 -
 
 ### Added
 - Added core files.
-
 - See git history for changes.

--- a/lib/http.js
+++ b/lib/http.js
@@ -335,7 +335,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       // session ID to the `challenge`... each time we verify a VP we should
       // clear the challenge as it is intended to be a nonce
 
-      // TODO: verify VCs in VP and that they match requirements of `flow`
       const result = await vcIssuer.issue({actor: null, accountId, instance, credential});
       const presentation = vc.createPresentation({verifiableCredential: result});
       res.json(presentation);

--- a/lib/http.js
+++ b/lib/http.js
@@ -311,7 +311,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     asyncHandler(async (req, res) => {
 
       // TODO: inspect/validate API token
-      // token will need to align with issuer.id
+      // token will need to align with req.params.instanceId
 
       const {
         // FIXME implement options

--- a/lib/http.js
+++ b/lib/http.js
@@ -325,16 +325,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       // get associated configuration
 
-      // TODO: a configuration will contain a schema that the incoming
+      // TODO: options will contain a schema that the incoming
       // credential will be validated against
       // const configuration = await vcIssuer.configurations.get({instance});
-
-      // TODO: verify VP
-      // TODO: when verifying the VP, it includes a `challenge` that must be
-      // checked against a previously stored value (we could map the user's
-      // session ID to the `challenge`... each time we verify a VP we should
-      // clear the challenge as it is intended to be a nonce
-
+      // TODO: options will contain an output object
+      // Add the ability to export as JSONLD | JSON | or cbor
+      // Add the ability to issue using a JWT or LD-Proof
       const result = await vcIssuer.issue({actor: null, accountId, instance, credential});
       const presentation = vc.createPresentation({verifiableCredential: result});
       res.json(presentation);

--- a/lib/http.js
+++ b/lib/http.js
@@ -6,6 +6,7 @@
 const {asyncHandler} = require('bedrock-express');
 const base64url = require('base64url-universal');
 const bedrock = require('bedrock');
+const vc = require('vc-js');
 const brAccount = require('bedrock-account');
 const crypto = require('crypto');
 //const {config} = bedrock;
@@ -303,7 +304,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       }));
       res.json(results);
     }));
-  // issue a VC if the posted data meets business rules, this must include
+  // issue a single VC if the posted data meets business rules, this must include
   // verifying a VP included in the posted data
   app.post(
     routes.issueCredential,
@@ -320,7 +321,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       } = req.body;
       const {issuerId} = req.params;
       // get instance for issuer
-      const {instance} = await vcIssuer.instances.get(issuerId);
+      const {instance} = await vcIssuer.instances.get({id: issuerId});
       const {controller: accountId} = instance;
 
       // get associated configuration
@@ -337,8 +338,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
       // TODO: verify VCs in VP and that they match requirements of `flow`
       const result = await vcIssuer.issue({actor: null, accountId, instance, credential});
-      // FIXME wrap issuedCredential in a VerifiablePresentation
-      res.json(result);
+      const presentation = vc.createPresentation({verifiableCredential: result});
+      res.json(presentation);
     }));
 
 });

--- a/lib/http.js
+++ b/lib/http.js
@@ -28,7 +28,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       instance: '/vc-issuer/instances/:instanceId',
       instanceIssuer: '/vc-issuer/instances/:instanceId/issuer',
       automatedIssue: '/vc-issuer/issue',
-      issueCredential: '/issuers/:issuerId/credentials',
+      issueCredential: '/issuers/:instanceId/credentials',
       getUser: '/vc-issuer/instances/:instanceId/users',
       claimUser: '/vc-issuer/instances/:instanceId/claim-user',
       user: '/vc-issuer/instances/:instanceId/users/:userId',

--- a/lib/http.js
+++ b/lib/http.js
@@ -27,6 +27,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       instance: '/vc-issuer/instances/:instanceId',
       instanceIssuer: '/vc-issuer/instances/:instanceId/issuer',
       automatedIssue: '/vc-issuer/issue',
+      issueCredential: '/issuers/:issuerId/credentials',
       getUser: '/vc-issuer/instances/:instanceId/users',
       claimUser: '/vc-issuer/instances/:instanceId/claim-user',
       user: '/vc-issuer/instances/:instanceId/users/:userId',
@@ -302,4 +303,42 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       }));
       res.json(results);
     }));
+  // issue a VC if the posted data meets business rules, this must include
+  // verifying a VP included in the posted data
+  app.post(
+    routes.issueCredential,
+    // TODO: validate body
+    asyncHandler(async (req, res) => {
+
+      // TODO: inspect/validate API token
+      // token will need to align with issuer.id
+
+      const {
+        // FIXME implement options
+        options = {},
+        credential,
+      } = req.body;
+      const {issuerId} = req.params;
+      // get instance for issuer
+      const {instance} = await vcIssuer.instances.get(issuerId);
+      const {controller: accountId} = instance;
+
+      // get associated configuration
+
+      // TODO: a configuration will contain a schema that the incoming
+      // credential will be validated against
+      // const configuration = await vcIssuer.configurations.get({instance});
+
+      // TODO: verify VP
+      // TODO: when verifying the VP, it includes a `challenge` that must be
+      // checked against a previously stored value (we could map the user's
+      // session ID to the `challenge`... each time we verify a VP we should
+      // clear the challenge as it is intended to be a nonce
+
+      // TODO: verify VCs in VP and that they match requirements of `flow`
+      const result = await vcIssuer.issue({actor: null, accountId, instance, credential});
+      // FIXME wrap issuedCredential in a VerifiablePresentation
+      res.json(result);
+    }));
+
 });

--- a/lib/http.js
+++ b/lib/http.js
@@ -319,7 +319,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         credential,
       } = req.body;
       const {instanceId} = req.params;
-      // get instance for issuer
       const {instance} = await vcIssuer.instances.get({id: instanceId});
       const {controller: accountId} = instance;
 

--- a/lib/http.js
+++ b/lib/http.js
@@ -318,7 +318,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         options = {},
         credential,
       } = req.body;
-      const {issuerId} = req.params;
+      const {instanceId} = req.params;
       // get instance for issuer
       const {instance} = await vcIssuer.instances.get({id: issuerId});
       const {controller: accountId} = instance;

--- a/lib/http.js
+++ b/lib/http.js
@@ -304,11 +304,10 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       }));
       res.json(results);
     }));
-  // issue a single VC if the posted data meets business rules, this must include
-  // verifying a VP included in the posted data
+  // issue a single VC if the posted data meets business rules.
   app.post(
     routes.issueCredential,
-    // TODO: validate body
+    // TODO: validate body {options, credential}
     asyncHandler(async (req, res) => {
 
       // TODO: inspect/validate API token

--- a/lib/http.js
+++ b/lib/http.js
@@ -320,7 +320,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       } = req.body;
       const {instanceId} = req.params;
       // get instance for issuer
-      const {instance} = await vcIssuer.instances.get({id: issuerId});
+      const {instance} = await vcIssuer.instances.get({id: instanceId});
       const {controller: accountId} = instance;
 
       // get associated configuration


### PR DESCRIPTION
Adds a single new endpoint: POST `issuers/:issuerId/credentials`.

1. Takes in a json object with a credential and optional options.
2.Finds the issuer instance using the `req.params.issuerId`
3. signs using that instance the credential
4. packages the credential inside of a VP
5. returns the VP to the client (they will need to set the holder themselves)