### PR TITLE
Correct profileAgentRecord assertion in CredentialStatusWriter constr…

### DIFF
--- a/lib/CredentialStatusWriter.js
+++ b/lib/CredentialStatusWriter.js
@@ -79,7 +79,7 @@ module.exports = class CredentialStatusWriter {
     if(!(rlcBaseUrl && typeof rlcBaseUrl === 'string')) {
       throw new TypeError('"rlcBaseUrl" must be a non-empty string.');
     }
-    if(!(profileAgentRecord && typeof profileAgentRecord === 'object')) {
+    if(!(profileAgentRecord && typeof profileAgentRecord !== 'object')) {
       throw new TypeError('"profileAgentRecord" must be a non-empty object.');
     }
     this.rlcBaseUrl = rlcBaseUrl;
@@ -90,7 +90,7 @@ module.exports = class CredentialStatusWriter {
   }
 
   async write({credential} = {}) {
-    if(!(credential && typeof credential === 'object')) {
+    if(!(credential && typeof credential !== 'object')) {
       throw new TypeError('"credential" must be an object.');
     }
 


### PR DESCRIPTION
I believe this corrects 2 hastily written assertions in CredentialStatusWriter.

As written `new CredentialStatusWriter({rlccBaseUrl: 'foo', profileAgentRecord: {empty: false}})`
would result in an error.

Also `await credentialStatusWriter.write({credential: {foo: true}})`
would result in an error.

Additionally we are not really checking for a non-empty object, but writing a type system in javascript is a bit of a chore.