### PR TITLE
Fix typos preventing proper treatment of duplicate VC statuses.

### DIFF
--- a/lib/CredentialStatusWriter.js
+++ b/lib/CredentialStatusWriter.js
@@ -125,7 +125,7 @@ module.exports = class CredentialStatusWriter {
     const {listShard} = this;
     if(listShard) {
       const {credentialStatus} = credential;
-      if(!(credentialStatus && typeof credentialStatus !== 'object')) {
+      if(!(credentialStatus && typeof credentialStatus === 'object')) {
         throw new TypeError('"credentialStatus" must be an object.');
       }
 

--- a/lib/CredentialStatusWriter.js
+++ b/lib/CredentialStatusWriter.js
@@ -132,16 +132,20 @@ module.exports = class CredentialStatusWriter {
       // 1.1. Read the IAD.
       const {indexAssignmentEdvDoc, item: {rlSequence}} = listShard;
       const doc = await indexAssignmentEdvDoc.read();
+      listShard.indexAssignmentDoc = doc;
 
       // 1.2. If the IAD's RL sequence matches the one from the LS and the
       //   IAD's latest assigned index value is behind the index in the VC's
       //   `credentialStatus` field:
       const {revocationListIndex} = credentialStatus;
       const localIndex = _getLocalIndex({listShard, revocationListIndex});
+
+      // the nextLocalIndex must be greater than the localIndex from the
+      // credentialStatus
       if(doc.content.rlSequence === rlSequence &&
-        doc.content.nextLocalIndex < localIndex) {
+        doc.content.nextLocalIndex <= localIndex) {
         // 1.2.1. Update the latest assigned index value.
-        doc.content.nextLocalIndex = localIndex;
+        doc.content.nextLocalIndex = localIndex + 1;
         // 1.2.2. CW update the IAD.
         try {
           await indexAssignmentEdvDoc.write({doc});

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -25,6 +25,9 @@ const {EdvClient, EdvDocument} = require('edv-client');
 require('./config');
 
 exports.issue = async ({credential, suite}) => {
+  // vc-js.issue may be fixed to not mutate credential
+  // see: https://github.com/digitalbazaar/vc-js/issues/76
+  credential = {...credential};
   return vc.issue({credential, documentLoader, suite});
 };
 

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -58,7 +58,7 @@ exports.issue = async ({credential, profileAgentRecord}) => {
         {item: verifiableCredential, meta: {}});
       issued = true;
     } catch(e) {
-      if(!(e.name === 'DuplicateError' && credentialStatusWriter &&
+      if(!(e.name === 'InvalidStateError' && credentialStatusWriter &&
         await credentialStatusWriter.exists({credential}))) {
         // not a duplicate error, throw it
         throw e;

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -12,10 +12,15 @@ const rlcs = require('./rlc');
 // load config defaults
 require('./config');
 
+// exported for testing purposes
+exports._CredentialStatusWriter = CredentialStatusWriter;
+
 exports.issue = async ({credential, profileAgentRecord}) => {
   const {issuer, suite, credentialsCollection, profileAgent} =
     await getIssuingInterfaces({profileAgentRecord});
 
+  // clone credential to avoid mutation
+  credential = {...credential};
   credential.issuer = issuer;
 
   // TODO: get revocation list option from instance (profile) configuration

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -60,7 +60,7 @@ exports.issue = async ({credential, profileAgentRecord}) => {
     } catch(e) {
       if(!(e.name === 'InvalidStateError' && credentialStatusWriter &&
         await credentialStatusWriter.exists({credential}))) {
-        // not a duplicate error, throw it
+        // error not caused by a duplicate credential status, throw it
         throw e;
       }
       // ignore duplicate errors based on credential status and loop

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -8,7 +8,6 @@ const {create} = require('apisauce');
 const {httpsAgent} = require('bedrock-https-agent');
 const helpers = require('./helpers.js');
 const sinon = require('sinon');
-const Runner = require('mocha/lib/runner');
 const brPassport = require('bedrock-passport');
 
 const api = create({
@@ -21,22 +20,10 @@ const api = create({
 describe('API', function() {
   describe('issue POST endpoint', function() {
     let agents;
-    beforeEach(async function() {
+    before(async function() {
       const accountId = 'urn:uuid:e9b57b37-2fea-43d6-82cb-f4a02c144e38';
       agents = await helpers.insertIssuerAgent(
         {id: accountId, token: 'test-token'});
-      if(Runner.prototype.hasOwnProperty('uncaughtEnd')) {
-        sinon.stub(Runner.prototype, 'uncaughtEnd').returns(true);
-      }
-      if(Runner.prototype.hasOwnProperty('_uncaught')) {
-        sinon.stub(Runner.prototype, '_uncaught').returns(true);
-      }
-    });
-    after(function(done) {
-      const timer = setTimeout(() => {
-        clearTimeout(timer);
-        done();
-      }, 2000);
     });
     it('should issue a credential', async function() {
       const {integration: {secrets}} = agents;

--- a/test/mocha/20-recovery.js
+++ b/test/mocha/20-recovery.js
@@ -1,0 +1,98 @@
+/*!
+ * Copyright (c) 2020 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const {config} = require('bedrock');
+const {create} = require('apisauce');
+const {httpsAgent} = require('bedrock-https-agent');
+const helpers = require('./helpers.js');
+const sinon = require('sinon');
+const {_CredentialStatusWriter} = require('bedrock-vc-issuer');
+
+const api = create({
+  baseURL: `${config.server.baseUri}/vc-issuer`,
+  httpsAgent,
+  timeout: 10000,
+});
+
+describe('Failure recovery', function() {
+  let agents;
+  before(async function() {
+    const accountId = 'urn:uuid:43f47a1f-acaf-4dd1-8597-001a8b0637e3';
+    agents = await helpers.insertIssuerAgent(
+      {id: accountId, token: 'token-43f47a1f-acaf-4dd1-8597-001a8b0637e3'});
+  });
+
+  // stub modules in order to simulate failure conditions
+  let credentialStatusWriterStub;
+  let mathRandomStub;
+  before(async () => {
+    // Math.random will always return 0
+    // this will ensure that the same shard is selected every time
+    // see _chooseRandom helper in ListManager.js
+    mathRandomStub = sinon.stub(Math, 'random').callsFake(() => 0);
+    // credentiaStatuslWriter.finish is a noop
+    // making this a noop is simulating a failure where the revocation list
+    // bookkeeping was not completed after an issuance
+    credentialStatusWriterStub = sinon.stub(
+      _CredentialStatusWriter.prototype, 'finish').callsFake(async () => {});
+  });
+  after(async () => {
+    mathRandomStub.restore();
+    credentialStatusWriterStub.restore();
+  });
+
+  // first issue a VC that is partially completed enough to return the
+  // VC, however, the revocation list index bookkeeping is not updated
+  // The earlier failure is detected by the second issue of a VC and
+  // the bookkeping is repaired
+  it('should handle a crashed/partial issuance', async () => {
+    const {integration: {secrets}} = agents;
+    let credential = helpers.cloneCredential();
+    credential.id = 'urn:someId1';
+
+    const {token} = secrets;
+    const result1 = await api.post(
+      '/issue',
+      {credential},
+      {headers: {Authorization: `Bearer ${token}`}}
+    );
+    const result1CredentialStatusId = result1.data.verifiableCredential
+      .credentialStatus.id;
+
+    credential = helpers.cloneCredential();
+    credential.id = 'urn:someId2';
+    const result2 = await api.post(
+      '/issue',
+      {credential},
+      {headers: {Authorization: `Bearer ${token}`}}
+    );
+    result2.status.should.equal(200);
+    should.exist(result2.data);
+    result2.data.should.be.an('object');
+    should.exist(result2.data.verifiableCredential);
+    const {verifiableCredential} = result2.data;
+    verifiableCredential.should.be.an('object');
+    should.exist(verifiableCredential['@context']);
+    should.exist(verifiableCredential.id);
+    should.exist(verifiableCredential.type);
+    should.exist(verifiableCredential.issuer);
+    should.exist(verifiableCredential.issuanceDate);
+    should.exist(verifiableCredential.expirationDate);
+    should.exist(verifiableCredential.credentialSubject);
+    verifiableCredential.credentialSubject.should.be.an('object');
+    should.exist(verifiableCredential.credentialStatus);
+    should.exist(verifiableCredential.proof);
+    verifiableCredential.proof.should.be.an('object');
+    const result2CredentialStatusId = result2.data.verifiableCredential
+      .credentialStatus.id;
+
+    // this test ensures that the two credentials are not issued with the same
+    // revocation list index / hash fragment
+    result2CredentialStatusId.should.not.equal(result1CredentialStatusId);
+    const result1Hash = parseInt(result1CredentialStatusId.split('#')[1]);
+    const result2Hash = parseInt(result2CredentialStatusId.split('#')[1]);
+    result2Hash.should.equal(result1Hash + 1);
+  });
+});

--- a/test/package.json
+++ b/test/package.json
@@ -31,7 +31,7 @@
     "bedrock-security-context": "^3.0.0",
     "bedrock-server": "^2.6.0",
     "bedrock-ssm-mongodb": "^3.0.0",
-    "bedrock-test": "^5.1.0",
+    "bedrock-test": "^5.3.0",
     "bedrock-validation": "^4.2.0",
     "bedrock-vc-issuer": "file:..",
     "bedrock-vc-revocation-list-context": "^1.0.0",


### PR DESCRIPTION
This fix is needed to properly test any changes to `credentialStatusWriter.exists()` usage in `issuer.js`. It is, of course, needed generally. We need to figure out how to create a test that will cause duplicate status codes to be generated so we can trigger this code path.