### PR TITLE
Pin github actions to node 18.7 for now.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
           - 27017:27017
     strategy:
       matrix:
-        node-version: [16.x, 18.x]
+        node-version: [16.x, 18.7]
     steps:
     - uses: actions/checkout@v2
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Pins github actions to `18.7` for now to avoid bugs with `content-encoding`  errors.