### PR TITLE
Don't await eddsa-2022 createSuite function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-vc-issuer ChangeLog
 
+## 19.3.1 -
+
+### Fixed
+- Do not await `createSuite`.
+- Change `eddsa-2022` `createSuite` function to non-async function.
+
 ## 19.3.0 - 2022-09-21
 
 ### Added

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -324,7 +324,7 @@ async function _getIssuerAndSuite({
         public: true
       }, e);
   }
-  const suite = await createSuite({signer: assertionMethodKey});
+  const suite = createSuite({signer: assertionMethodKey});
   return {issuer, suite};
 }
 

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -42,7 +42,7 @@ export function getSuiteParams({config, suiteName}) {
   return {zcap, createSuite, referenceId};
 }
 
-async function _createEddsa2022Suite({signer}) {
+function _createEddsa2022Suite({signer}) {
   // remove milliseconds precision
   const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
   const cryptosuite = eddsa2022CryptoSuite;


### PR DESCRIPTION
Removes the async and awaits from `createSuite` as the three existing suites don't need to be awaited.
I started out awaiting the `eddsa-2022` suite because I thought I might need to await some type of key conversion,
turns out we just needed algorithm set on the key.