### PR TITLE
Add strict:false to body-parser.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-vc-issuer ChangeLog
 
+## 19.4.0 -
+
+### Changed
+- Allow any valid json as `req.body` not just Objects and Arrays.
+
 ## 19.3.1 - 2022-09-28
 
 ### Fixed

--- a/lib/http.js
+++ b/lib/http.js
@@ -22,7 +22,12 @@ const {util: {BedrockError}} = bedrock;
 
 // FIXME: remove and apply at top-level application
 bedrock.events.on('bedrock-express.configure.bodyParser', app => {
-  app.use(bodyParser.json({limit: '10MB', type: ['json', '+json']}));
+  app.use(bodyParser.json({
+    // allow json values that are not just objects or arrays
+    strict: false,
+    limit: '10MB',
+    type: ['json', '+json']
+  }));
 });
 
 export async function addRoutes({app, service} = {}) {


### PR DESCRIPTION
This is a draft because apparently we want the `body-parser` options in the top level project.
Can we just make the limit configurable?