### PR TITLE
Add option mandatory points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # bedrock-vc-issuer ChangeLog
 
+## 25.2.0 -
+
+### Added
+- Add the ability to send `options.mandatoryPointers` to the `/credentials/issue` route.
+
+### Changed
+- Passing `options` to the `/credentials/issue` route no longer throws.
+
 ## 25.1.0 - 2023-11-14
 
 ### Added

--- a/lib/http.js
+++ b/lib/http.js
@@ -60,16 +60,7 @@ export async function addRoutes({app, service} = {}) {
       try {
         const {config} = req.serviceObject;
         const {credential, options} = req.body;
-
-        // options are not supported, everything must be preconfigured for
-        // this issuer instance
-        if(options) {
-          throw new BedrockError(
-            'Options not supported.',
-            'NotSupportedError', {httpStatusCode: 400, public: true});
-        }
-
-        const verifiableCredential = await issue({credential, config});
+        const verifiableCredential = await issue({credential, config, options});
         res.status(201).json({verifiableCredential});
       } catch(error) {
         logger.error(error.message, {error});

--- a/lib/http.js
+++ b/lib/http.js
@@ -18,8 +18,6 @@ import cors from 'cors';
 import {logger} from './logger.js';
 import {createValidateMiddleware as validate} from '@bedrock/validation';
 
-const {util: {BedrockError}} = bedrock;
-
 // FIXME: remove and apply at top-level application
 bedrock.events.on('bedrock-express.configure.bodyParser', app => {
   app.use(bodyParser.json({

--- a/lib/issuer.js
+++ b/lib/issuer.js
@@ -24,7 +24,7 @@ const serviceType = 'vc-issuer';
 // exported for testing purposes
 export const _CredentialStatusWriter = CredentialStatusWriter;
 
-export async function issue({credential, config} = {}) {
+export async function issue({credential, config, options} = {}) {
   assert.object(credential, 'credential');
   assert.object(config, 'config');
 
@@ -37,7 +37,7 @@ export async function issue({credential, config} = {}) {
     // only fetch `documentStore` if a status list is configured; otherwise,
     // it is not needed
     statusListOptions.length > 0 ? _getDocumentStore({config}) : {},
-    _getIssuerAndSuite({config, suiteName})
+    _getIssuerAndSuite({config, suiteName, options})
   ]);
   const {edvClient} = documentStore;
 
@@ -296,7 +296,7 @@ async function _getDocumentStore({config}) {
 }
 
 async function _getIssuerAndSuite({
-  config, suiteName = config.issueOptions.suiteName
+  config, suiteName = config.issueOptions.suiteName, options
 }) {
   // get suite params for issuing a VC
   const {createSuite, referenceId} = getSuiteParams({config, suiteName});
@@ -324,7 +324,7 @@ async function _getIssuerAndSuite({
         public: true
       }, e);
   }
-  const suite = createSuite({signer: assertionMethodKey});
+  const suite = createSuite({signer: assertionMethodKey, config, options});
   return {issuer, suite};
 }
 

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -115,12 +115,11 @@ function _createEcdsaRdfc2019Suite({signer} = {}) {
   });
 }
 
-function _createEcdsaSd2023Suite({signer} = {}) {
+function _createEcdsaSd2023Suite({signer, options} = {}) {
+  const mandatoryPointers = options?.mandatoryPointers ||
+    ['/issuer', '/issuanceDate'];
   const cryptosuite = createEcdsaSd2023SignCryptosuite({
-    mandatoryPointers: [
-      '/issuer',
-      '/issuanceDate'
-    ]
+    mandatoryPointers
   });
   const diProof = new DataIntegrityProof({
     signer,

--- a/lib/suites.js
+++ b/lib/suites.js
@@ -82,47 +82,56 @@ export function getSuiteParams({config, suiteName}) {
 }
 
 function _createEddsa2022Suite({signer}) {
-  // remove milliseconds precision
-  const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
-  const cryptosuite = eddsa2022CryptoSuite;
   return new DataIntegrityProof({
-    signer, date, cryptosuite, legacyContext: true
+    signer,
+    date: getISODateTime(),
+    cryptosuite: eddsa2022CryptoSuite,
+    legacyContext: true
   });
 }
 
 function _createEcdsa2019Suite({signer} = {}) {
-  // remove milliseconds precision
-  const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
-  const cryptosuite = ecdsa2019CryptoSuite;
   return new DataIntegrityProof({
-    signer, date, cryptosuite, legacyContext: true
+    signer,
+    date: getISODateTime(),
+    cryptosuite: ecdsa2019CryptoSuite,
+    legacyContext: true
   });
 }
 
 function _createEddsaRdfc2022Suite({signer}) {
-  // remove milliseconds precision
-  const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
-  const cryptosuite = eddsaRdfc2022CryptoSuite;
-  return new DataIntegrityProof({signer, date, cryptosuite});
+  return new DataIntegrityProof({
+    signer,
+    date: getISODateTime(),
+    cryptosuite: eddsaRdfc2022CryptoSuite
+  });
 }
 
 function _createEcdsaRdfc2019Suite({signer} = {}) {
-  // remove milliseconds precision
-  const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
-  const cryptosuite = ecdsaRdfc2019CryptoSuite;
-  return new DataIntegrityProof({signer, date, cryptosuite});
+  return new DataIntegrityProof({
+    signer,
+    date: getISODateTime(),
+    cryptosuite: ecdsaRdfc2019CryptoSuite
+  });
 }
 
 function _createEcdsaSd2023Suite({signer} = {}) {
-  // remove milliseconds precision
-  const date = new Date().toISOString().replace(/\.\d+Z$/, 'Z');
   const cryptosuite = createEcdsaSd2023SignCryptosuite({
     mandatoryPointers: [
       '/issuer',
       '/issuanceDate'
     ]
   });
-  const diProof = new DataIntegrityProof({signer, date, cryptosuite});
+  const diProof = new DataIntegrityProof({
+    signer,
+    date: getISODateTime(),
+    cryptosuite
+  });
   diProof.proof = {id: `urn:uuid:${uuid()}`};
   return diProof;
+}
+
+function getISODateTime(date = new Date()) {
+  // remove milliseconds precision
+  return date.toISOString().replace(/\.\d+Z$/, 'Z');
 }


### PR DESCRIPTION
Features:
1. You can now pass options to `/credentials/issue`
2. Passing `options.mandatoryPointers` to `credentials/issue` will overwrite the default mandatoryPointer
3. 2 new tests related to selective disclosure and mandatoryPointers are added

Remaining:
- [ ] Is this a minor release? 
- [ ] Should invalid mandatoryPointers return 500 OperationError?