### PR TITLE
Use version of vc-bitstring-status-list pinned to update-vc-2.0.

### DIFF
--- a/test/package.json
+++ b/test/package.json
@@ -48,7 +48,7 @@
     "@digitalbazaar/edv-client": "^16.0.0",
     "@digitalbazaar/ezcap": "^4.0.0",
     "@digitalbazaar/http-client": "^4.0.0",
-    "@digitalbazaar/vc-bitstring-status-list": "github:digitalbazaar/vc-bitstring-status-list#main",
+    "@digitalbazaar/vc-bitstring-status-list": "github:digitalbazaar/vc-bitstring-status-list#update-vc-2.0",
     "@digitalbazaar/vc-status-list": "^7.1.0",
     "@digitalbazaar/webkms-client": "^14.0.0",
     "c8": "^9.1.0",


### PR DESCRIPTION
the test project depends on a version of `vc-bitstring-status-list` that uses a stale branch of `@digitalbazaar/vc`.

See:
https://github.com/digitalbazaar/vc-bitstring-status-list/pull/5

this just ensures that all versions of VC used in this branch are uniform in sub-dependencies.