### PR TITLE
Throw 400 invalid json pointer

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -142,7 +142,7 @@ export async function issue({credential, documentLoader, suites}) {
     return credential;
   } catch(e) {
     // throw 400 for JSON pointer related errors
-    if(e?.name === 'TypeError' && e?.message?.includes('JSON pointer')) {
+    if(e.name === 'TypeError' && e.message?.includes('JSON pointer')) {
       throw new BedrockError(
         e.message, {
           name: 'DataError',

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -134,7 +134,9 @@ export async function issue({credential, documentLoader, suites}) {
   credential = {...credential};
   // issue using each suite
   for(const suite of suites) {
+    // update credential with latest proof(s)
     credential = await vc.issue({credential, documentLoader, suite});
   }
+  // return credential with a proof for each suite
   return credential;
 }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -129,14 +129,30 @@ export async function getIssuerAndSuites({config, options}) {
 // helpers must export this function and not `issuer` to prevent circular
 // dependencies via `CredentialStatusWriter`, `ListManager` and `issuer`
 export async function issue({credential, documentLoader, suites}) {
-  // vc-js.issue may be fixed to not mutate credential
-  // see: https://github.com/digitalbazaar/vc-js/issues/76
-  credential = {...credential};
-  // issue using each suite
-  for(const suite of suites) {
-    // update credential with latest proof(s)
-    credential = await vc.issue({credential, documentLoader, suite});
+  try {
+    // vc-js.issue may be fixed to not mutate credential
+    // see: https://github.com/digitalbazaar/vc-js/issues/76
+    credential = {...credential};
+    // issue using each suite
+    for(const suite of suites) {
+      // update credential with latest proof(s)
+      credential = await vc.issue({credential, documentLoader, suite});
+    }
+    // return credential with a proof for each suite
+    return credential;
+  } catch(e) {
+    // throw 400 for JSON pointer related errors
+    if(e?.name === 'TypeError' && e?.message?.includes('JSON pointer')) {
+      throw new BedrockError(
+        e.message, {
+          name: 'DataError',
+          details: {
+            httpStatusCode: 400,
+            public: true
+          },
+          cause: e
+        });
+    }
+    throw e;
   }
-  // return credential with a proof for each suite
-  return credential;
 }

--- a/test/mocha/20-credentials.js
+++ b/test/mocha/20-credentials.js
@@ -427,8 +427,7 @@ describe('issue APIs', () => {
               json: {
                 credential,
                 options: {
-                  ...issueOptions,
-                  mandatoryPointers: ['/issuer']
+                  ...issueOptions
                 }
               }
             });

--- a/test/mocha/20-credentials.js
+++ b/test/mocha/20-credentials.js
@@ -857,6 +857,7 @@ describe('issue APIs', () => {
           it('fails to issue a valid credential w/ invalid ' +
             '"options.mandatoryPointers"', async () => {
             let error;
+            const missingPointer = '/nonExistentPointer';
             try {
               const credential = klona(mockCredential);
               const zcapClient = helpers.createZcapClient({capabilityAgent});
@@ -867,7 +868,7 @@ describe('issue APIs', () => {
                   credential,
                   options: {
                     ...issueOptions,
-                    mandatoryPointers: ['/nonExistentPointer']
+                    mandatoryPointers: [missingPointer]
                   }
                 }
               });
@@ -875,7 +876,10 @@ describe('issue APIs', () => {
               error = e;
             }
             should.exist(error);
-            error.data.type.should.equal('OperationError');
+            error.data.type.should.equal('DataError');
+            error.status.should.equal(400);
+            error.data.message.should.equal(
+              `JSON pointer "${missingPointer}" does not match document.`);
           });
         }
         // extra information tests


### PR DESCRIPTION
1. Removes posting `mandatoryPointers` from the basic issuance tests.
2. Adds a try catch to the issue function for catching issuer specific errors
3. errors related to JSON pointers return 400.