### PR TITLE
Improve error handling.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # bedrock-vc-issuer ChangeLog
 
+## 27.0.3 - 2024-xx-xx
+
+### Changed
+- Improve error handling.
+  - Return 400 instead of 500 for some common errors.
+
 ## 27.0.2 - 2024-08-26
 
 ### Fixed

--- a/lib/http.js
+++ b/lib/http.js
@@ -104,26 +104,68 @@ export async function addRoutes({app, service} = {}) {
         res.status(201).json(body);
       } catch(error) {
         logger.error(error.message, {error});
-        // will be thrown for safe mode violations
-        if(error.name === 'jsonld.ValidationError') {
-          throw new BedrockError('Invalid credential.', {
-            name: 'SyntaxError',
-            details: {
-              httpStatusCode: 400,
-              public: true
-            },
-            cause: error
-          });
+        // wrap if not already a BedrockError
+        if(!(error instanceof BedrockError)) {
+          _throwWrappedError({cause: error});
         }
-        // TODO: handle other possible errors
-        // in particular @digitalbazaar/vc throws many simple 'TypeError' and
-        // 'Error' errors. Difficult to distinguish them from other errors.
-
-        // default to other layers, likely will be an ISE/500
         throw error;
       }
 
       // meter operation usage
       metering.reportOperationUsage({req});
     }));
+}
+
+// known error cause names to map to 'DataError'
+const _dataErrors = new Set([
+  'DataError',
+  'jsonld.InvalidUrl',
+  'jsonld.ValidationError'
+]);
+// TODO: handle other possible errors
+// in particular @digitalbazaar/vc throws many simple 'TypeError' and
+// 'Error' errors. Difficult to distinguish them from other errors.
+
+function _throwWrappedError({cause}) {
+  const {name/*, message*/} = cause;
+
+  // TODO: should this be verbose with the top level error?  it's also in the
+  // 'error' field.
+  //const error = new BedrockError(message ?? 'Invalid credential.', {
+  const error = new BedrockError('Invalid credential.', {
+    name: _dataErrors.has(name) ? 'DataError' : 'OperationError',
+    details: {
+      // using sanitized 'error' field instead of 'cause' due to bedrock
+      // currently filtering out non-BedrockError causes.
+      error: _stripStackTrace(cause),
+      httpStatusCode: cause.httpStatusCode ?? 400,
+      public: true
+    }
+  });
+
+  throw error;
+}
+
+function _stripStackTrace(error) {
+  // copy error data
+  const stripped = {...error};
+  if(error.name) {
+    stripped.name = error.name;
+  }
+  if(error.message) {
+    stripped.message = error.message;
+  }
+  // remove stack
+  delete stripped.stack;
+  // strip other potential stack data
+  if(stripped.errors) {
+    stripped.errors = stripped.errors.map(_stripStackTrace);
+  }
+  if(stripped.cause) {
+    stripped.cause = _stripStackTrace(stripped.cause);
+  }
+  if(stripped.details?.cause) {
+    stripped.details.cause = _stripStackTrace(stripped.details.cause);
+  }
+  return stripped;
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -10,9 +10,15 @@ import {getDocumentStore} from './helpers.js';
 import {issue} from './issuer.js';
 import {issueCredentialBody} from '../schemas/bedrock-vc-issuer.js';
 import {logger} from './logger.js';
+import {serializeError} from 'serialize-error';
 import {createValidateMiddleware as validate} from '@bedrock/validation';
 
 const {util: {BedrockError}} = bedrock;
+
+const ALLOWED_ERROR_KEYS = [
+  'message', 'name', 'type', 'data', 'errors', 'error', 'details', 'cause',
+  'status'
+];
 
 // FIXME: remove and apply at top-level application
 bedrock.events.on('bedrock-express.configure.bodyParser', app => {
@@ -147,25 +153,26 @@ function _throwWrappedError({cause}) {
 }
 
 function _stripStackTrace(error) {
-  // copy error data
-  const stripped = {...error};
-  if(error.name) {
-    stripped.name = error.name;
+  // serialize error and allow-list specific properties
+  const serialized = serializeError(error);
+  const _error = {};
+  for(const key of ALLOWED_ERROR_KEYS) {
+    if(serialized[key] !== undefined) {
+      _error[key] = serialized[key];
+    }
   }
-  if(error.message) {
-    stripped.message = error.message;
-  }
-  // remove stack
-  delete stripped.stack;
   // strip other potential stack data
-  if(stripped.errors) {
-    stripped.errors = stripped.errors.map(_stripStackTrace);
+  if(_error.errors) {
+    _error.errors = _error.errors.map(_stripStackTrace);
   }
-  if(stripped.cause) {
-    stripped.cause = _stripStackTrace(stripped.cause);
+  if(Array.isArray(_error.details?.errors)) {
+    _error.details.errors = _error.details.errors.map(_stripStackTrace);
   }
-  if(stripped.details?.cause) {
-    stripped.details.cause = _stripStackTrace(stripped.details.cause);
+  if(_error.cause) {
+    _error.cause = _stripStackTrace(_error.cause);
   }
-  return stripped;
+  if(_error.details?.cause) {
+    _error.details.cause = _stripStackTrace(_error.details.cause);
+  }
+  return _error;
 }

--- a/lib/http.js
+++ b/lib/http.js
@@ -111,7 +111,8 @@ export async function addRoutes({app, service} = {}) {
             details: {
               httpStatusCode: 400,
               public: true
-            }
+            },
+            cause: error
           });
         }
         // TODO: handle other possible errors

--- a/lib/http.js
+++ b/lib/http.js
@@ -104,6 +104,21 @@ export async function addRoutes({app, service} = {}) {
         res.status(201).json(body);
       } catch(error) {
         logger.error(error.message, {error});
+        // will be thrown for safe mode violations
+        if(error.name === 'jsonld.ValidationError') {
+          throw new BedrockError('Invalid credential.', {
+            name: 'SyntaxError',
+            details: {
+              httpStatusCode: 400,
+              public: true
+            }
+          });
+        }
+        // TODO: handle other possible errors
+        // in particular @digitalbazaar/vc throws many simple 'TypeError' and
+        // 'Error' errors. Difficult to distinguish them from other errors.
+
+        // default to other layers, likely will be an ISE/500
         throw error;
       }
 

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "cors": "^2.8.5",
     "klona": "^2.0.6",
     "lru-cache": "^6.0.0",
+    "serialize-error": "^11.0.3",
     "uuid": "^10.0.0"
   },
   "peerDependencies": {

--- a/test/mocha/70-misc.js
+++ b/test/mocha/70-misc.js
@@ -1,0 +1,203 @@
+/*!
+ * Copyright (c) 2020-2024 Digital Bazaar, Inc. All rights reserved.
+ */
+import * as bedrock from '@bedrock/core';
+import * as helpers from './helpers.js';
+//import {createRequire} from 'node:module';
+import {klona} from 'klona';
+import {mockData} from './mock.data.js';
+import {v4 as uuid} from 'uuid';
+
+//const require = createRequire(import.meta.url);
+
+// NOTE: using embedded context in mockCredential:
+// https://www.w3.org/2018/credentials/examples/v1
+//const mockCredential = require('./mock-credential.json');
+//const mockCredentialV2 = require('./mock-credential-v2.json');
+
+const badCredentials = [
+  {
+    title: 'empty credential',
+    credential: {},
+    expect: {
+      statusCode: 400,
+      name: 'ValidationError',
+      message: null
+    }
+  },
+  {
+    title: 'unkonwn context',
+    credential: {
+      '@context': [
+        'https://www.w3.org/ns/credentials/v2',
+        'bogus.example'
+      ],
+      type: ['VerifiableCredential'],
+      credentialSubject: {
+        'ex:thing': true
+      }
+    },
+    expect: {
+      // FIXME
+      statusCode: 400,
+      name: 'jsonld.InvalidUrl',
+      message: null
+    }
+  },
+  {
+    title: 'empty subject',
+    credential: {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential'],
+      credentialSubject: {}
+    },
+    expect: {
+      // FIXME
+      statusCode: 500,
+      name: null,
+      message: null
+    }
+  },
+  {
+    title: 'undefined terms',
+    credential: {
+      '@context': ['https://www.w3.org/ns/credentials/v2'],
+      type: ['VerifiableCredential', 'UndefinedType'],
+      credentialSubject: {
+        undefinedTerm: 'notDefinedInContext'
+      }
+    },
+    expect: {
+      statusCode: 400,
+      name: 'SyntaxError',
+      message: 'Invalid credential.'
+    }
+  }
+];
+
+describe.only('fail for bed credentials', () => {
+  let suites;
+  let capabilityAgent;
+  let zcaps;
+  let noStatusListIssuerId;
+  let noStatusListIssuerRootZcap;
+  beforeEach(async () => {
+    // generate a proof set using all of these suites in each test
+    suites = [{
+      name: 'Ed25519Signature2020',
+      algorithm: 'Ed25519'
+    }, {
+      name: 'eddsa-rdfc-2022',
+      algorithm: 'Ed25519'
+    }, {
+      name: 'ecdsa-rdfc-2019',
+      algorithm: 'P-256'
+    }, {
+      name: 'ecdsa-sd-2023',
+      algorithm: 'P-256',
+      // require these options (do not allow client to override)
+      options: {
+        mandatoryPointers: ['/issuer']
+      }
+    }, {
+      name: 'ecdsa-xi-2023',
+      algorithm: 'P-256'
+    }, {
+      name: 'bbs-2023',
+      algorithm: 'Bls12381G2',
+      // require these options (do not allow client to override)
+      options: {
+        mandatoryPointers: ['/issuer']
+      }
+    }];
+
+    // generate a `did:web` DID for the issuer
+    const {host} = bedrock.config.server;
+    const localId = uuid();
+    const did = `did:web:${encodeURIComponent(host)}:did-web:${localId}`;
+
+    // provision dependencies
+    ({capabilityAgent, zcaps} = await helpers.provisionDependencies({
+      did, cryptosuites: suites, status: false, zcaps: true
+    }));
+
+    // create issue options
+    const issueOptions = {
+      issuer: did,
+      cryptosuites: suites.map(suite => {
+        const {name, options, zcapReferenceIds} = suite;
+        const cryptosuite = {name, zcapReferenceIds};
+        if(options) {
+          cryptosuite.options = options;
+        }
+        return cryptosuite;
+      })
+    };
+
+    // create `did:web` DID document for issuer
+    const didDocument = {
+      '@context': [
+        'https://www.w3.org/ns/did/v1',
+        'https://w3id.org/security/suites/ed25519-2020/v1',
+        'https://w3id.org/security/multikey/v1'
+      ],
+      id: did,
+      verificationMethod: [],
+      assertionMethod: []
+    };
+    for(const {assertionMethodKey} of suites) {
+      const description = await assertionMethodKey.getKeyDescription();
+      delete description['@context'];
+      didDocument.verificationMethod.push(description);
+      didDocument.assertionMethod.push(description.id);
+    }
+    // add DID doc to map with DID docs to be served
+    mockData.didWebDocuments.set(localId, didDocument);
+
+    // create issuer instance w/ no status list options
+    const noStatusListIssuerConfig = await helpers.createIssuerConfig({
+      capabilityAgent, zcaps, issueOptions
+    });
+    noStatusListIssuerId = noStatusListIssuerConfig.id;
+    noStatusListIssuerRootZcap =
+      `urn:zcap:root:${encodeURIComponent(noStatusListIssuerId)}`;
+  });
+  // filter using 'only' and 'skip'
+  const _hasOnly = badCredentials.some(c => c.skip !== true && c.only === true);
+  const _badCredentials = badCredentials
+    .filter(c => c.skip !== true)
+    .filter(c => !_hasOnly || c.only === true);
+  for(const testCred of _badCredentials) {
+    it(`fails for ${testCred.title}`, async () => {
+      const credential = klona(testCred.credential);
+      let error;
+      let result;
+      try {
+        const zcapClient = helpers.createZcapClient({capabilityAgent});
+        result = await zcapClient.write({
+          url: `${noStatusListIssuerId}/credentials/issue`,
+          capability: noStatusListIssuerRootZcap,
+          json: {
+            credential,
+            options: {
+              extraInformation: 'abc'
+            }
+          }
+        });
+      } catch(e) {
+        error = e;
+      }
+      should.exist(error);
+      should.not.exist(result);
+      if(testCred.expect.statusCode) {
+        error.status.should.equal(testCred.expect.statusCode);
+      }
+      if(testCred.expect.name !== null) {
+        error.data.name.should.equal(testCred.expect.name);
+      }
+      if(testCred.expect.message !== null) {
+        error.data.message.should.equal(testCred.expect.message);
+      }
+    });
+  }
+});


### PR DESCRIPTION
- Attempt to improve error handling.
- One goal is to return 400 instead of 500 for some common errors.
- I wasn't sure where to put failure tests.  Made a "misc" file that can run a handful of simple tests and check for errors.  I think the boilerplate copied from another file could be simplified.  Help wanted.
- I'm not sure what this API should do for errors.  Should any details be returned to client?  There are many possible causes of errors coming from  the issuer endpoint code.  jsonld lib, vc lib, other libs could fail on input data.  What should be exposed?  How do we check for errors from libs like vc that only use generic 'Error' or 'TypeError'?

Addresses: https://github.com/digitalbazaar/bedrock-vc-issuer/issues/169.